### PR TITLE
Update README.md by removing usage section

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -4,12 +4,8 @@
 
 Configures iptables rules for transparent proxy and network traffic management. Sets up TPROXY rules and blocks external access to specified ports.
 
-**Usage:**  
 Requires: root privileges, [fish shell](https://fishshell.com/), and [iptables](https://netfilter.org/projects/iptables/index.html) installed and available in PATH.  
-Example:  
 
-```sh
-sudo fish scripts/firewall.fish
 ## install_docker.fish
 
 Automates the Docker installation process. Downloads the signed key and installs via the Aliyun repository mirror.


### PR DESCRIPTION
Removed usage instructions for firewall.fish script.

## Summary by Sourcery

Documentation:
- Removed the **Usage** block and example invocation instructions for *firewall.fish* in scripts/README.md